### PR TITLE
Feat/add macros

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -1,3 +1,4 @@
+// Package ast contains the definitions for all of the nodes in the Abstract Syntax Tree (AST)
 package ast
 
 import (
@@ -339,6 +340,31 @@ func (hl *HashLiteral) String() string {
 	out.WriteString("{")
 	out.WriteString(strings.Join(pairs, ", "))
 	out.WriteString("}")
+
+	return out.String()
+}
+
+type MacroLiteral struct {
+	Token      token.Token     // The "macro" token
+	Parameters []*Identifier   // A slice of macro parameters
+	Body       *BlockStatement // The body of the macro
+}
+
+func (ml *MacroLiteral) expressionNode()      {}
+func (ml *MacroLiteral) TokenLiteral() string { return ml.Token.Literal }
+func (ml *MacroLiteral) String() string {
+	var out bytes.Buffer
+
+	params := []string{}
+	for _, param := range ml.Parameters {
+		params = append(params, param.String())
+	}
+
+	out.WriteString(ml.TokenLiteral())
+	out.WriteString("(")
+	out.WriteString(strings.Join(params, ", "))
+	out.WriteString(") ")
+	out.WriteString(ml.Body.String())
 
 	return out.String()
 }

--- a/pkg/ast/modify.go
+++ b/pkg/ast/modify.go
@@ -2,6 +2,8 @@ package ast
 
 type ModifierFunc func(Node) Node
 
+// BUG: Does not update the Token field for the parent node
+
 // Apply a modifer to an AST node.
 func Modify(node Node, modifier ModifierFunc) Node {
 	// TODO: Replace underscores with proper error handling

--- a/pkg/ast/modify.go
+++ b/pkg/ast/modify.go
@@ -4,6 +4,8 @@ type ModifierFunc func(Node) Node
 
 // Apply a modifer to an AST node.
 func Modify(node Node, modifier ModifierFunc) Node {
+	// TODO: Replace underscores with proper error handling
+
 	switch node := node.(type) {
 	case *Program:
 		for i, statement := range node.Statements {
@@ -12,6 +14,65 @@ func Modify(node Node, modifier ModifierFunc) Node {
 
 	case *ExpressionStatement:
 		node.Expression, _ = Modify(node.Expression, modifier).(Expression)
+
+	case *CallExpression:
+		for i, argument := range node.Arguments {
+			node.Arguments[i], _ = Modify(argument, modifier).(Expression)
+		}
+
+	case *InfixExpression:
+		node.Left, _ = Modify(node.Left, modifier).(Expression)
+		node.Right, _ = Modify(node.Right, modifier).(Expression)
+
+	case *PrefixExpression:
+		node.Right, _ = Modify(node.Right, modifier).(Expression)
+
+	case *IndexEpression:
+		node.Left, _ = Modify(node.Left, modifier).(Expression)
+		node.Index, _ = Modify(node.Index, modifier).(Expression)
+
+	case *IfExpression:
+		node.Condition, _ = Modify(node.Condition, modifier).(Expression)
+		node.Consequence, _ = Modify(node.Consequence, modifier).(*BlockStatement)
+		if node.Alternative != nil {
+			node.Alternative, _ = Modify(node.Alternative, modifier).(*BlockStatement)
+		}
+
+	case *BlockStatement:
+		for i, statement := range node.Statements {
+			node.Statements[i], _ = Modify(statement, modifier).(Statement)
+		}
+
+	case *ReturnStatement:
+		node.ReturnValue, _ = Modify(node.ReturnValue, modifier).(Expression)
+
+	case *LetStatement:
+		node.Value, _ = Modify(node.Value, modifier).(Expression)
+
+	case *FunctionLiteral:
+		if node.Parameters != nil {
+			for i, parameter := range node.Parameters {
+				node.Parameters[i], _ = Modify(parameter, modifier).(*Identifier)
+			}
+		}
+		node.Body, _ = Modify(node.Body, modifier).(*BlockStatement)
+
+	case *ArrayLiteral:
+		for i, element := range node.Elements {
+			node.Elements[i], _ = Modify(element, modifier).(Expression)
+		}
+
+	case *HashLiteral:
+		modifiedPairs := make(map[Expression]Expression)
+
+		for key, value := range node.Pairs {
+			modifiedKey, _ := Modify(key, modifier).(Expression)
+			modifiedValue, _ := Modify(value, modifier).(Expression)
+
+			modifiedPairs[modifiedKey] = modifiedValue
+		}
+
+		node.Pairs = modifiedPairs
 	}
 
 	return modifier(node)

--- a/pkg/ast/modify.go
+++ b/pkg/ast/modify.go
@@ -1,0 +1,18 @@
+package ast
+
+type ModifierFunc func(Node) Node
+
+// Apply a modifer to an AST node.
+func Modify(node Node, modifier ModifierFunc) Node {
+	switch node := node.(type) {
+	case *Program:
+		for i, statement := range node.Statements {
+			node.Statements[i], _ = Modify(statement, modifier).(Statement)
+		}
+
+	case *ExpressionStatement:
+		node.Expression, _ = Modify(node.Expression, modifier).(Expression)
+	}
+
+	return modifier(node)
+}

--- a/pkg/ast/modify_test.go
+++ b/pkg/ast/modify_test.go
@@ -1,0 +1,52 @@
+package ast
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestModify(t *testing.T) {
+	one := func() Expression { return &IntegerLiteral{Value: 1} }
+	two := func() Expression { return &IntegerLiteral{Value: 2} }
+
+	turnOneIntoTwo := func(node Node) Node {
+		integer, ok := node.(*IntegerLiteral)
+		if !ok {
+			return node
+		}
+
+		if integer.Value != 1 {
+			return node
+		}
+
+		integer.Value = 2
+		return integer
+	}
+
+	tests := []struct {
+		input    Node
+		expected Node
+	}{
+		{one(), two()},
+		{
+			&Program{
+				Statements: []Statement{
+					&ExpressionStatement{Expression: one()},
+				},
+			},
+			&Program{
+				Statements: []Statement{
+					&ExpressionStatement{Expression: two()},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		modified := Modify(test.input, turnOneIntoTwo)
+
+		if !reflect.DeepEqual(modified, test.expected) {
+			t.Errorf("not equal. got=%#v, expected=%#v", modified, test.expected)
+		}
+	}
+}

--- a/pkg/ast/modify_test.go
+++ b/pkg/ast/modify_test.go
@@ -40,6 +40,72 @@ func TestModify(t *testing.T) {
 				},
 			},
 		},
+		{
+			&InfixExpression{Left: one(), Operator: "+", Right: two()},
+			&InfixExpression{Left: two(), Operator: "+", Right: two()},
+		},
+		{
+			&InfixExpression{Left: two(), Operator: "+", Right: one()},
+			&InfixExpression{Left: two(), Operator: "+", Right: two()},
+		},
+		{
+			&PrefixExpression{Operator: "-", Right: one()},
+			&PrefixExpression{Operator: "-", Right: two()},
+		},
+		{
+			&IndexEpression{Left: one(), Index: one()},
+			&IndexEpression{Left: two(), Index: two()},
+		},
+		{
+			&IfExpression{
+				Condition: one(),
+				Consequence: &BlockStatement{
+					Statements: []Statement{
+						&ExpressionStatement{Expression: one()},
+					},
+				},
+				Alternative: &BlockStatement{
+					Statements: []Statement{
+						&ExpressionStatement{Expression: one()},
+					},
+				},
+			},
+			&IfExpression{
+				Condition: two(),
+				Consequence: &BlockStatement{
+					Statements: []Statement{
+						&ExpressionStatement{Expression: two()},
+					},
+				},
+				Alternative: &BlockStatement{
+					Statements: []Statement{
+						&ExpressionStatement{Expression: two()},
+					},
+				},
+			},
+		},
+		{&ReturnStatement{ReturnValue: one()}, &ReturnStatement{ReturnValue: two()}},
+		{&LetStatement{Value: one()}, &LetStatement{Value: two()}},
+		{
+			&FunctionLiteral{
+				Body: &BlockStatement{
+					Statements: []Statement{
+						&ExpressionStatement{Expression: one()},
+					},
+				},
+			},
+			&FunctionLiteral{
+				Body: &BlockStatement{
+					Statements: []Statement{
+						&ExpressionStatement{Expression: two()},
+					},
+				},
+			},
+		},
+		{
+			&ArrayLiteral{Elements: []Expression{one(), two()}},
+			&ArrayLiteral{Elements: []Expression{two(), two()}},
+		},
 	}
 
 	for _, test := range tests {
@@ -47,6 +113,26 @@ func TestModify(t *testing.T) {
 
 		if !reflect.DeepEqual(modified, test.expected) {
 			t.Errorf("not equal. got=%#v, expected=%#v", modified, test.expected)
+		}
+	}
+
+	hashLiteral := &HashLiteral{
+		Pairs: map[Expression]Expression{
+			one(): one(),
+			one(): one(),
+		},
+	}
+
+	Modify(hashLiteral, turnOneIntoTwo)
+
+	for key, val := range hashLiteral.Pairs {
+		key, _ := key.(*IntegerLiteral)
+		if key.Value != 2 {
+			t.Errorf("value is not %d, got=%d", 2, key.Value)
+		}
+		val, _ := val.(*IntegerLiteral)
+		if val.Value != 2 {
+			t.Errorf("value is not %d, got=%d", 2, val.Value)
 		}
 	}
 }

--- a/pkg/evaluator/builtins.go
+++ b/pkg/evaluator/builtins.go
@@ -1,9 +1,8 @@
 package evaluator
 
 import (
-	"os"
-
 	"fmt"
+	"os"
 
 	"github.com/grantwforsythe/monkeylang/pkg/object"
 )

--- a/pkg/evaluator/builtins.go
+++ b/pkg/evaluator/builtins.go
@@ -3,6 +3,8 @@ package evaluator
 import (
 	"os"
 
+	"fmt"
+
 	"github.com/grantwforsythe/monkeylang/pkg/object"
 )
 
@@ -127,6 +129,14 @@ var builtin = map[string]*object.Builtin{
 		Fn: func(args ...object.Object) object.Object {
 			os.Exit(0)
 			return &object.Null{}
+		},
+	},
+	"puts": {
+		Fn: func(args ...object.Object) object.Object {
+			for _, arg := range args {
+				fmt.Println(arg.Inspect())
+			}
+			return NULL
 		},
 	},
 }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -60,6 +60,13 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		return &object.Function{Body: node.Body, Env: env, Parameters: node.Parameters}
 
 	case *ast.CallExpression:
+		// TODO: Refactor this
+		// Skip evaluation of argument when calling `quote`
+		// Quote only accepts one argument
+		if node.Function.TokenLiteral() == "quote" {
+			return &object.Quote{Node: node.Arguments[0]}
+		}
+
 		fn := Eval(node.Function, env)
 		if isError(fn) {
 			return fn

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -64,7 +64,7 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		// Skip evaluation of argument when calling `quote`
 		// Quote only accepts one argument
 		if node.Function.TokenLiteral() == "quote" {
-			return &object.Quote{Node: node.Arguments[0]}
+			return quote(node.Arguments[0], env)
 		}
 
 		fn := Eval(node.Function, env)

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -187,6 +187,7 @@ func TestEvalErrorHandling(t *testing.T) {
 			"unhashable key: NULL",
 		},
 		{`{"a": 1}[fn(x) { x }]`, "unhashable key: FUNCTION"},
+		{"1[0]", "index operator not supported: INTEGER"},
 	}
 
 	for _, tt := range tests {
@@ -735,6 +736,7 @@ func TestHashIndexExpressions(t *testing.T) {
 		}
 	}
 }
+
 func testEval(input string) object.Object {
 	l := lexer.New(input)
 	p := parser.New(l)

--- a/pkg/evaluator/macro_expansion.go
+++ b/pkg/evaluator/macro_expansion.go
@@ -1,0 +1,122 @@
+package evaluator
+
+import (
+	"github.com/grantwforsythe/monkeylang/pkg/ast"
+	"github.com/grantwforsythe/monkeylang/pkg/object"
+)
+
+// TODO: Handle nested macro definitions
+
+// DefineMacro defines all top-level macros in the global environment and then removes all macro nodes from the AST.
+func DefineMacros(program *ast.Program, env *object.Environment) {
+	// Indexes for all macro definitions
+	indexes := []int{}
+
+	// Define all macro in the environment and store the indexes for where they are located.
+	for i, statement := range program.Statements {
+		// TODO: Have a better assertion
+		if isMacroDefinition(statement) {
+			// These conditions are already met in isMacroDefinition so no need to check again
+			letStatement, _ := statement.(*ast.LetStatement)
+			macroLiteral, _ := letStatement.Value.(*ast.MacroLiteral)
+
+			// Add the macro to the environment
+			env.Set(letStatement.Name.String(), &object.Macro{
+				Parameters: macroLiteral.Parameters,
+				Body:       macroLiteral.Body,
+				Env:        env,
+			})
+
+			// Store the index for the macro
+			indexes = append(indexes, i)
+		}
+	}
+
+	// Remove all macro nodes from the AST
+	for _, idx := range indexes {
+		program.Statements = append(program.Statements[:idx], program.Statements[idx+1:]...)
+	}
+}
+
+// ExpandMacros evaluate calls to macros and replaces the original call expression with the result of the evaluation in the AST.
+func ExpandMacros(program ast.Node, env *object.Environment) ast.Node {
+	return ast.Modify(program, func(node ast.Node) ast.Node {
+		exp, ok := node.(*ast.CallExpression)
+		if !ok {
+			return node
+		}
+
+		macro, ok := isMacroCall(exp, env)
+		if !ok {
+			return node
+		}
+
+		args := quoteArgs(exp.Arguments)
+		extendedEnv := extendMacroEnv(macro, args)
+
+		eval := Eval(macro.Body, extendedEnv)
+
+		quote, ok := eval.(*object.Quote)
+		if !ok {
+			panic(
+				"only AST nodes can be returned from macros, i.e. only Quote objects can be returned",
+			)
+		}
+
+		return quote.Node
+	})
+}
+
+// isMacroDefinition returns true if a statement is an *ast.MacroLiteral definition, else false.
+func isMacroDefinition(statement ast.Statement) bool {
+	letStatement, ok := statement.(*ast.LetStatement)
+	if !ok {
+		return false
+	}
+
+	_, ok = letStatement.Value.(*ast.MacroLiteral)
+	return ok
+}
+
+// isMacroCall returns true if a call expression is on a macro, else false.
+func isMacroCall(exp *ast.CallExpression, env *object.Environment) (*object.Macro, bool) {
+	identifier, ok := exp.Function.(*ast.Identifier)
+	if !ok {
+		return nil, false
+	}
+
+	obj, ok := env.Get(identifier.Value)
+	if !ok {
+		return nil, false
+	}
+
+	macro, ok := obj.(*object.Macro)
+	if !ok {
+		return nil, false
+	}
+
+	return macro, true
+}
+
+// quoteArgs converts all arguments to a macro into *object.Quote objects.
+func quoteArgs(args []ast.Expression) []*object.Quote {
+	var quoteArgs []*object.Quote
+
+	for _, arg := range args {
+		quoteArgs = append(quoteArgs, &object.Quote{Node: arg})
+	}
+
+	return quoteArgs
+}
+
+// extendMacroEnv adds all arguments to a macro's scope.
+// Returns the extended environment for the macro.
+func extendMacroEnv(macro *object.Macro, args []*object.Quote) *object.Environment {
+	extendedEnv := object.NewEnclosedEnvironment(macro.Env)
+
+	for i, param := range macro.Parameters {
+		extendedEnv.Set(param.Value, args[i])
+	}
+
+	return extendedEnv
+}

--- a/pkg/evaluator/macro_expansion_test.go
+++ b/pkg/evaluator/macro_expansion_test.go
@@ -13,7 +13,7 @@ func TestDefineMacros(t *testing.T) {
 	input := `
 	let number = 1;
 	let function = fn(x, y) { x + y };
-	let macro! = macro(x, y) { x + y };
+	let mymacro = macro(x, y) { x + y };
 	`
 
 	program := testParseProgram(input)
@@ -32,9 +32,9 @@ func TestDefineMacros(t *testing.T) {
 		t.Fatalf("'function' should be undefined")
 	}
 
-	obj, ok := env.Get("macro!")
+	obj, ok := env.Get("mymacro")
 	if !ok {
-		t.Fatalf("'macro!' should not be undefined")
+		t.Fatalf("'mymacro' should not be undefined")
 	}
 
 	macro, ok := obj.(*object.Macro)

--- a/pkg/evaluator/macro_expansion_test.go
+++ b/pkg/evaluator/macro_expansion_test.go
@@ -1,0 +1,109 @@
+package evaluator
+
+import (
+	"testing"
+
+	"github.com/grantwforsythe/monkeylang/pkg/ast"
+	"github.com/grantwforsythe/monkeylang/pkg/lexer"
+	"github.com/grantwforsythe/monkeylang/pkg/object"
+	"github.com/grantwforsythe/monkeylang/pkg/parser"
+)
+
+func TestDefineMacros(t *testing.T) {
+	input := `
+	let number = 1;
+	let function = fn(x, y) { x + y };
+	let macro! = macro(x, y) { x + y };
+	`
+
+	program := testParseProgram(input)
+	env := object.NewEnvironment()
+	DefineMacros(program, env)
+
+	if len(program.Statements) != 2 {
+		t.Fatalf("the number of statements if not equal to 2. got=%d", len(program.Statements))
+	}
+
+	if _, ok := env.Get("number"); ok {
+		t.Fatalf("'number' should be undefined")
+	}
+
+	if _, ok := env.Get("function"); ok {
+		t.Fatalf("'function' should be undefined")
+	}
+
+	obj, ok := env.Get("macro!")
+	if !ok {
+		t.Fatalf("'macro!' should not be undefined")
+	}
+
+	macro, ok := obj.(*object.Macro)
+	if !ok {
+		t.Fatalf("obj is not of type *object.Macro. got=%T", macro)
+	}
+
+	if len(macro.Parameters) != 2 {
+		t.Fatalf("macro is expected to have 2 parameters. got=%d", len(macro.Parameters))
+	}
+
+	if macro.Parameters[0].String() != "x" {
+		t.Fatalf(
+			"the first parameter of the macro is not equal to 'x'. got=%s",
+			macro.Parameters[0].String(),
+		)
+	}
+
+	if macro.Parameters[1].String() != "y" {
+		t.Fatalf(
+			"the first parameter of the macro is not equal to 'y'. got=%s",
+			macro.Parameters[1].String(),
+		)
+	}
+
+	if macro.Body.String() != "(x + y)" {
+		t.Fatalf("the body of the macro is not equal to 'x + y'. got=%s", macro.Body.String())
+	}
+}
+
+func TestExpandMacros(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			`
+			let infixExpression = macro() { quote(1 + 2); };
+			infixExpression();
+			`,
+			`(1 + 2)`,
+		},
+		// TODO: Check why unquote doesn't evaluate the parameters
+		{
+			`
+			let reverse = macro(a, b) { quote(unquote(b) - unquote(a)); };
+			reverse(2 + 2, 10 - 5);
+			`,
+			`(10 - 5) - (2 + 2)`,
+		},
+	}
+
+	for _, test := range tests {
+		expected := testParseProgram(test.expected)
+		program := testParseProgram(test.input)
+
+		env := object.NewEnvironment()
+		DefineMacros(program, env)
+		expanded := ExpandMacros(program, env)
+
+		if expanded.String() != expected.String() {
+			t.Errorf("not equal. want=%q, got=%q",
+				expected.String(), expanded.String())
+		}
+	}
+}
+
+func testParseProgram(input string) *ast.Program {
+	l := lexer.New(input)
+	p := parser.New(l)
+	return p.ParseProgram()
+}

--- a/pkg/evaluator/macro_expansion_test.go
+++ b/pkg/evaluator/macro_expansion_test.go
@@ -85,7 +85,21 @@ func TestExpandMacros(t *testing.T) {
 			`,
 			`(10 - 5) - (2 + 2)`,
 		},
-	}
+
+		{
+			`
+            let unless = macro(condition, consequence, alternative) {
+                quote(if (!(unquote(condition))) {
+                    unquote(consequence);
+                } else {
+                    unquote(alternative);
+                });
+            };
+
+            unless(10 > 5, puts("not greater"), puts("greater"));
+            `,
+			`if (!(10 > 5)) { puts("not greater") } else { puts("greater") }`,
+		}}
 
 	for _, test := range tests {
 		expected := testParseProgram(test.expected)

--- a/pkg/evaluator/quote_unqote.go
+++ b/pkg/evaluator/quote_unqote.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grantwforsythe/monkeylang/pkg/object"
 )
 
+// Create a Quote object evaluating any calls to unquote
 func quote(node ast.Node, env *object.Environment) object.Object {
 	return &object.Quote{Node: evalUnquoteCalls(node, env)}
 }

--- a/pkg/evaluator/quote_unqote.go
+++ b/pkg/evaluator/quote_unqote.go
@@ -1,0 +1,44 @@
+package evaluator
+
+import (
+	"github.com/grantwforsythe/monkeylang/pkg/ast"
+	"github.com/grantwforsythe/monkeylang/pkg/object"
+)
+
+func quote(node ast.Node, env *object.Environment) object.Object {
+	return &object.Quote{Node: evalUnquoteCalls(node, env)}
+}
+
+func evalUnquoteCalls(quote ast.Node, env *object.Environment) ast.Node {
+	return ast.Modify(quote, func(node ast.Node) ast.Node {
+		if !isUnquoteCall(node) {
+			return node
+		}
+
+		// We make this same assertion in isUnquoteCall so no need to do it again
+		call, _ := node.(*ast.CallExpression)
+
+		// Can only handle one expression
+		if len(call.Arguments) != 1 {
+			return node
+		}
+
+		eval := Eval(call.Arguments[0], env)
+
+		convertible, ok := eval.(object.Convertible)
+		if !ok {
+			return node
+		}
+
+		return convertible.ToNode()
+	})
+}
+
+// Check if a node is a call expression for unquote.
+func isUnquoteCall(node ast.Node) bool {
+	fn, ok := node.(*ast.CallExpression)
+	if !ok {
+		return false
+	}
+	return fn.Function.TokenLiteral() == "unquote"
+}

--- a/pkg/evaluator/quote_unquote_test.go
+++ b/pkg/evaluator/quote_unquote_test.go
@@ -29,8 +29,40 @@ func TestQuote(t *testing.T) {
 		}
 
 		if quote.Node.String() != test.expected {
-			t.Fatalf("quote.Node.String() is not equal to 5. got=%s", quote.Node.String())
+			t.Fatalf(
+				"quote.Node.String() is not equal to %s. got=%s",
+				test.expected,
+				quote.Node.String(),
+			)
 		}
 	}
 
+}
+
+func TestQuoteUnqote(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"quote(unquote(4))", "4"},
+		{"quote(unquote(4 + 4))", "8"},
+		{"quote(8 + unquote(4 + 4))", "8 + 8"},
+	}
+
+	for _, test := range tests {
+		eval := testEval(test.input)
+		quote, ok := eval.(*object.Quote)
+
+		if !ok {
+			t.Fatalf("expected *object.Quote. got=%T (%+v)", eval, eval)
+		}
+
+		if quote.Node == nil {
+			t.Fatalf("quote.Node is nil")
+		}
+
+		if quote.Node.String() != test.expected {
+			t.Fatalf("quote.Node.String() is not equal to 5. got=%s", quote.Node.String())
+		}
+	}
 }

--- a/pkg/evaluator/quote_unquote_test.go
+++ b/pkg/evaluator/quote_unquote_test.go
@@ -50,7 +50,7 @@ func TestQuoteUnqote(t *testing.T) {
 		{`let value = 8; quote(8 + unquote(value))`, "(8 + 8)"},
 		{"quote(unquote(true))", "true"},
 		{"quote(unquote(true == false))", "false"},
-		{"quote(4 + unquote(4 + 4 + quote(5 + 5)))", "(4 + 8 + (5 + 5))"},
+		{"quote(4 + unquote(quote(5 + 5)))", "(4 + (5 + 5))"},
 	}
 
 	for _, test := range tests {

--- a/pkg/evaluator/quote_unquote_test.go
+++ b/pkg/evaluator/quote_unquote_test.go
@@ -46,7 +46,8 @@ func TestQuoteUnqote(t *testing.T) {
 	}{
 		{"quote(unquote(4))", "4"},
 		{"quote(unquote(4 + 4))", "8"},
-		{"quote(8 + unquote(4 + 4))", "8 + 8"},
+		{"quote(8 + unquote(4 + 4))", "(8 + 8)"},
+		{`let value = 8; quote(8 + unquote(value))`, "(8 + 8)"},
 	}
 
 	for _, test := range tests {
@@ -62,7 +63,11 @@ func TestQuoteUnqote(t *testing.T) {
 		}
 
 		if quote.Node.String() != test.expected {
-			t.Fatalf("quote.Node.String() is not equal to 5. got=%s", quote.Node.String())
+			t.Fatalf(
+				"quote.Node.String() is not equal to %s. got=%s",
+				test.expected,
+				quote.Node.String(),
+			)
 		}
 	}
 }

--- a/pkg/evaluator/quote_unquote_test.go
+++ b/pkg/evaluator/quote_unquote_test.go
@@ -1,0 +1,36 @@
+package evaluator
+
+import (
+	"testing"
+
+	"github.com/grantwforsythe/monkeylang/pkg/object"
+)
+
+func TestQuote(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`quote(5)`, `5`},
+		{`quote(5 + 8)`, `(5 + 8)`},
+		{`quote(foobar)`, `foobar`},
+		{`quote(foobar + barfoo)`, `(foobar + barfoo)`},
+	}
+
+	for _, test := range tests {
+		eval := testEval(test.input)
+		quote, ok := eval.(*object.Quote)
+		if !ok {
+			t.Fatalf("expected *object.Quote. got=%T (%+v)", eval, eval)
+		}
+
+		if quote.Node == nil {
+			t.Fatalf("quote.Node is nil")
+		}
+
+		if quote.Node.String() != test.expected {
+			t.Fatalf("quote.Node.String() is not equal to 5. got=%s", quote.Node.String())
+		}
+	}
+
+}

--- a/pkg/evaluator/quote_unquote_test.go
+++ b/pkg/evaluator/quote_unquote_test.go
@@ -48,6 +48,9 @@ func TestQuoteUnqote(t *testing.T) {
 		{"quote(unquote(4 + 4))", "8"},
 		{"quote(8 + unquote(4 + 4))", "(8 + 8)"},
 		{`let value = 8; quote(8 + unquote(value))`, "(8 + 8)"},
+		{"quote(unquote(true))", "true"},
+		{"quote(unquote(true == false))", "false"},
+		{"quote(4 + unquote(4 + 4 + quote(5 + 5)))", "(4 + 8 + (5 + 5))"},
 	}
 
 	for _, test := range tests {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -1,3 +1,4 @@
+// Package lexer contains a lexer which will tokenize a string.
 package lexer
 
 import (
@@ -23,6 +24,7 @@ func New(input string) *Lexer {
 }
 
 // Get next character and advance the position in the input string.
+// If the current position is greater than the length of the input we've reached the end of the file.
 func (l *Lexer) readChar() {
 	if l.readPosition >= len(l.input) {
 		// ASCII "NUL" -> "end of file" or "haven't read anything'"
@@ -36,6 +38,7 @@ func (l *Lexer) readChar() {
 }
 
 // Peek the next character without advancing the position of the input string.
+// If the current position is greater than the length of the input we've reached the end of the file.
 func (l *Lexer) peekChar() byte {
 	if l.readPosition >= len(l.input) {
 		// EOF
@@ -71,6 +74,7 @@ func (l *Lexer) readIdentifier() string {
 }
 
 // TODO: Add support for character escaping, e.g. \", \n, etc
+
 // Read the contents of a string.
 func (l *Lexer) readString() string {
 	// Skip over the first '"'

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -29,6 +29,7 @@ let result = add(five, ten);
 	"'foo'";
 	[1, 2];
 	{"test": 42};
+	macro(x, y) { x + y };
 `
 
 	tests := []struct {
@@ -122,6 +123,18 @@ let result = add(five, ten);
 		{token.STRING, "test"},
 		{token.COLON, ":"},
 		{token.INT, "42"},
+		{token.RBRACE, "}"},
+		{token.SEMICOLON, ";"},
+		{token.MACRO, "macro"},
+		{token.LPAREN, "("},
+		{token.IDENT, "x"},
+		{token.COMMA, ","},
+		{token.IDENT, "y"},
+		{token.RPAREN, ")"},
+		{token.LBRACE, "{"},
+		{token.IDENT, "x"},
+		{token.PLUS, "+"},
+		{token.IDENT, "y"},
 		{token.RBRACE, "}"},
 		{token.SEMICOLON, ";"},
 		{token.EOF, ""},

--- a/pkg/object/environment.go
+++ b/pkg/object/environment.go
@@ -1,30 +1,35 @@
 package object
 
+// Environment represents the scope of a program.
 type Environment struct {
 	store map[string]Object
 	outer *Environment
 }
 
+// NewEnvironment creates a new global environment.
 func NewEnvironment() *Environment {
 	store := make(map[string]Object)
 	return &Environment{store: store, outer: nil}
 }
 
+// NewEnclosedEnvironment creates a new enclosed environment.
 func NewEnclosedEnvironment(outer *Environment) *Environment {
 	store := make(map[string]Object)
 	return &Environment{store: store, outer: outer}
 }
 
-func (e *Environment) Get(name string) (Object, bool) {
-	obj, ok := e.store[name]
+// Get gets the value associated with the identifier.
+func (e *Environment) Get(identifier string) (Object, bool) {
+	obj, ok := e.store[identifier]
 	// If the identifier does not exist in the current environment, continously search all other nested environements
 	if !ok && e.outer != nil {
-		obj, ok = e.outer.Get(name)
+		obj, ok = e.outer.Get(identifier)
 	}
 	return obj, ok
 }
 
-func (e *Environment) Set(name string, value Object) Object {
-	e.store[name] = value
+// Set stores a value in the environment for the given identifier.
+func (e *Environment) Set(identifier string, value Object) Object {
+	e.store[identifier] = value
 	return value
 }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -25,6 +25,7 @@ const (
 	ARRAY_OBJ        = "ARRAY"
 	HASH_OBJ         = "HASH"
 	QUOTE_OBJ        = "QUOTE"
+	MACRO_OBJ        = "MACRO"
 )
 
 type Object interface {
@@ -224,4 +225,29 @@ func (q *Quote) Inspect() string {
 }
 func (q *Quote) ToNode() ast.Node {
 	return q.Node
+}
+
+type Macro struct {
+	Parameters []*ast.Identifier
+	Body       *ast.BlockStatement
+	Env        *Environment
+}
+
+func (m *Macro) Type() ObjectType { return MACRO_OBJ }
+func (m *Macro) Inspect() string {
+	var out bytes.Buffer
+
+	params := []string{}
+	for _, param := range m.Parameters {
+		params = append(params, param.String())
+	}
+
+	out.WriteString("macro")
+	out.WriteString("(")
+	out.WriteString(strings.Join(params, ", "))
+	out.WriteString(")\n")
+	out.WriteString(m.Body.String())
+	out.WriteString("\n")
+
+	return out.String()
 }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"hash/fnv"
+	"strconv"
 	"strings"
 
 	"github.com/grantwforsythe/monkeylang/pkg/ast"
+	"github.com/grantwforsythe/monkeylang/pkg/token"
 )
 
 type ObjectType string
@@ -32,6 +34,12 @@ type Object interface {
 	Inspect() string
 }
 
+// Represents an Object that is convertible
+type Convertible interface {
+	// Convert object to resulting AST Node
+	ToNode() ast.Node
+}
+
 // Represents a hash key for an object
 type HashKey struct {
 	Type  ObjectType
@@ -53,6 +61,12 @@ func (i *Integer) Type() ObjectType { return INTEGER_OBJ }
 func (i *Integer) Inspect() string  { return fmt.Sprintf("%d", i.Value) }
 func (i *Integer) HashKey() HashKey {
 	return HashKey{Type: i.Type(), Value: uint64(i.Value)}
+}
+func (i *Integer) ToNode() ast.Node {
+	return &ast.IntegerLiteral{
+		Token: token.Token{Type: token.INT, Literal: strconv.FormatInt(i.Value, 10)},
+		Value: i.Value,
+	}
 }
 
 type Boolean struct {

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -187,6 +187,7 @@ func (h *Hash) Inspect() string {
 	return out.String()
 }
 
+// An unevaluated AST node
 type Quote struct {
 	Node ast.Node
 }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -22,6 +22,7 @@ const (
 	BUILTIN_OBJ      = "BUILTIN"
 	ARRAY_OBJ        = "ARRAY"
 	HASH_OBJ         = "HASH"
+	QUOTE_OBJ        = "QUOTE"
 )
 
 type Object interface {
@@ -184,4 +185,13 @@ func (h *Hash) Inspect() string {
 	out.WriteString("}")
 
 	return out.String()
+}
+
+type Quote struct {
+	Node ast.Node
+}
+
+func (q *Quote) Type() ObjectType { return QUOTE_OBJ }
+func (q *Quote) Inspect() string {
+	return fmt.Sprintf("QUOTE(%s)", q.Node.String())
 }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -222,3 +222,6 @@ func (q *Quote) Type() ObjectType { return QUOTE_OBJ }
 func (q *Quote) Inspect() string {
 	return fmt.Sprintf("QUOTE(%s)", q.Node.String())
 }
+func (q *Quote) ToNode() ast.Node {
+	return q.Node
+}

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -77,7 +77,6 @@ func (b *Boolean) Type() ObjectType { return BOOLEAN_OBJ }
 func (b *Boolean) Inspect() string  { return fmt.Sprintf("%t", b.Value) }
 func (b *Boolean) HashKey() HashKey {
 	var value uint64
-
 	if b.Value {
 		value = 1
 	} else {
@@ -85,6 +84,19 @@ func (b *Boolean) HashKey() HashKey {
 	}
 
 	return HashKey{Type: b.Type(), Value: value}
+}
+func (b *Boolean) ToNode() ast.Node {
+	var tokenType token.TokenType
+	if b.Value {
+		tokenType = token.TRUE
+	} else {
+		tokenType = token.FALSE
+	}
+
+	return &ast.BooleanExpression{
+		Token: token.Token{Type: tokenType, Literal: strconv.FormatBool(b.Value)},
+		Value: b.Value,
+	}
 }
 
 type Null struct{}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -82,6 +82,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
 	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
 	p.registerPrefix(token.LBRACE, p.parseHashLiteral)
+	p.registerPrefix(token.MACRO, p.parseMacroLiteral)
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
@@ -495,4 +496,22 @@ func (p *Parser) parseHashLiteral() ast.Expression {
 	p.nextToken()
 
 	return hash
+}
+
+func (p *Parser) parseMacroLiteral() ast.Expression {
+	lit := &ast.MacroLiteral{Token: p.currToken}
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+
+	lit.Parameters = p.parseFunctionParameters()
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+
+	lit.Body = p.parseBlockStatement()
+
+	return lit
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -908,6 +908,53 @@ func TestParsingEmptyHashLiteral(t *testing.T) {
 	}
 }
 
+func TestMacroLiteralParsing(t *testing.T) {
+	input := `macro(x, y) { x + y; }`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Statements does not contain %d statements. got=%d\n",
+			1, len(program.Statements))
+	}
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("statement is not ast.ExpressionStatement. got=%T",
+			program.Statements[0])
+	}
+
+	macro, ok := stmt.Expression.(*ast.MacroLiteral)
+	if !ok {
+		t.Fatalf("stmt.Expression is not ast.MacroLiteral. got=%T",
+			stmt.Expression)
+	}
+
+	if len(macro.Parameters) != 2 {
+		t.Fatalf("macro literal parameters wrong. want 2, got=%d\n",
+			len(macro.Parameters))
+	}
+
+	testLiteralExpression(t, macro.Parameters[0], "x")
+	testLiteralExpression(t, macro.Parameters[1], "y")
+
+	if len(macro.Body.Statements) != 1 {
+		t.Fatalf("macro.Body.Statements has not 1 statements. got=%d\n",
+			len(macro.Body.Statements))
+	}
+
+	bodyStmt, ok := macro.Body.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("macro body stmt is not ast.ExpressionStatement. got=%T",
+			macro.Body.Statements[0])
+	}
+
+	testInfixExpression(t, bodyStmt.Expression, "+", "x", "y")
+}
+
 func checkParserErrors(t *testing.T, p *Parser) {
 	errors := p.Errors()
 	if len(errors) == 0 {

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -16,6 +16,7 @@ const PROMPT = ">> "
 func Start(in io.Reader, out io.Writer) {
 	scanner := bufio.NewScanner(in)
 	env := object.NewEnvironment()
+	macroEnv := object.NewEnvironment()
 
 	for {
 		fmt.Fprint(out, PROMPT)
@@ -43,7 +44,10 @@ func Start(in io.Reader, out io.Writer) {
 			continue
 		}
 
-		eval := evaluator.Eval(program, env)
+		evaluator.DefineMacros(program, macroEnv)
+		expanded := evaluator.ExpandMacros(program, macroEnv)
+
+		eval := evaluator.Eval(expanded, env)
 		if eval != nil {
 			_, err := io.WriteString(out, eval.Inspect()+"\n")
 			if err != nil {

--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -1,3 +1,4 @@
+// Package strings contains utility functions for working with strings.
 package strings
 
 // Determine if a character is whitespace or not

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -1,52 +1,58 @@
+// Package token contains all of the tokens for the Monkey language.
 package token
 
 type TokenType string
 
+// TODO: Replace assignment operator `let` with `:=`
+// TODO: Replace fn defintion with func
+// TODO: Add a loop token
+// TODO: Add less/greater than or equal to operators
+
 const (
-	ILLEGAL = "ILLEGAL"
-	EOF     = "EOF"
+	ILLEGAL = "ILLEGAL" // Unrecognized token
+	EOF     = "EOF"     // End of file
 
-	IDENT = "IDENT" // add, foobar, x, y, ...
-	INT   = "INT"   // 1343456
+	IDENT  = "IDENT"  // Identifier, e.g. add, foobar, x, y
+	INT    = "INT"    // Integer literal, e.g. 1234
+	STRING = "STRING" // String literal, "Hello, World!"
 
-	ASSIGN   = "="
-	PLUS     = "+"
-	MINUS    = "-"
-	BANG     = "!"
-	ASTERISK = "*"
-	SLASH    = "/"
+	ASSIGN   = "=" // Assignment operator, "="
+	PLUS     = "+" // Additional operator, "+"
+	MINUS    = "-" // Subtraction operator, "-"
+	BANG     = "!" // Boolean inversion operator, "!"
+	ASTERISK = "*" // Multiplication operator, "*"
+	SLASH    = "/" // Division operator, "/"
 
-	LT = "<"
-	GT = ">"
+	LT = "<" // Less than operator, "<"
+	GT = ">" // Greater than operator, ">"
 
-	EQ     = "=="
-	NOT_EQ = "!="
+	EQ     = "==" // Equality operator, "=="
+	NOT_EQ = "!=" // Inverse equality opertor, "!="
 
-	COMMA     = ","
-	SEMICOLON = ";"
-	COLON     = ":"
+	COMMA     = "," // Comma, ","
+	SEMICOLON = ";" // Semicolon, ";"
+	COLON     = ":" // Colon, ":"
 
-	LPAREN   = "("
-	RPAREN   = ")"
-	LBRACE   = "{"
-	RBRACE   = "}"
-	LBRACKET = "["
-	RBRACKET = "]"
+	LPAREN   = "(" // Left parenthesis, "("
+	RPAREN   = ")" // Right parenthesis, ")"
+	LBRACE   = "{" // Left brace, "{"
+	RBRACE   = "}" // Rigth brace, "}"
+	LBRACKET = "[" // Left bracket, "["
+	RBRACKET = "]" // Right bracket, "]"
 
-	FUNCTION = "FUNCTION"
-	LET      = "LET"
-	TRUE     = "TRUE"
-	FALSE    = "FALSE"
-	IF       = "IF"
-	ELSE     = "ELSE"
-	RETURN   = "RETURN"
-	STRING   = "STRING"
+	FUNCTION = "FUNCTION" // Function definition, e.g. "fn(x, y)"
+	LET      = "LET"      // Assignment operator, "let"
+	TRUE     = "TRUE"     // Boolean literal "true"
+	FALSE    = "FALSE"    // Boolean literal "false"
+	IF       = "IF"       // Conditonal definition, "if"
+	ELSE     = "ELSE"     // Alternative conditional definition, "else"
+	RETURN   = "RETURN"   // Return statement, "return"
 	MACRO    = "MACRO"    // Macro definition, e.g. "macro(x, y)"
 )
 
 type Token struct {
-	Type    TokenType
-	Literal string
+	Type    TokenType // The type of token
+	Literal string    // The literal string of the token
 }
 
 var keywords = map[string]TokenType{
@@ -60,6 +66,8 @@ var keywords = map[string]TokenType{
 	"macro":  MACRO,
 }
 
+// Get the token associated with a keyword.
+// If the string is not a keyword it is an identifier token.
 func LookupIdent(ident string) TokenType {
 	if tok, ok := keywords[ident]; ok {
 		return tok

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -41,6 +41,7 @@ const (
 	ELSE     = "ELSE"
 	RETURN   = "RETURN"
 	STRING   = "STRING"
+	MACRO    = "MACRO"    // Macro definition, e.g. "macro(x, y)"
 )
 
 type Token struct {
@@ -56,6 +57,7 @@ var keywords = map[string]TokenType{
 	"if":     IF,
 	"else":   ELSE,
 	"return": RETURN,
+	"macro":  MACRO,
 }
 
 func LookupIdent(ident string) TokenType {


### PR DESCRIPTION
## Overview
Add (very buggy) macro system which utilizes three new key words:
1. quote - stops the evaluation of a node and returns a quote object
2. unquote - evaluate a node
3. macro - define a new macro which returns a quote object by definition

## Example
```
>> let unless = macro(condition, consequence, alternative) {
  quote(
    if (!(unquote(condition))) {
      unquote(consequence); 
    } else { 
      unquote(alternative); 
    }
  );
}
>> unless(10 > 5, puts("10 is greater than 5"), puts("10 is not greater than 5")
"10 is greater than 5" -- notice that null is not outputted and the other puts statement is not evaluated
```